### PR TITLE
Add summary from mailing list by Julian

### DIFF
--- a/achievements/plc4x.md
+++ b/achievements/plc4x.md
@@ -4,3 +4,11 @@
 We made nearly 70 commits (68) during the Hackathon to the ASF Repo.
 As some where working in their forks, we assume that we have overall about *100* commits during the Hackathon.
 Commits where made from many different people, including PMCs like Christofer, Tim and Julian but also from Community Members like Björn and Lukasz and newcommers that where met at the Hackathon like Niklas.
+
+Most notably we have a first version of the C# (or .NET) API finished by Björn and merged by Chris, so big props to those two! Then, Tim and Julian did a lot of refactoring for the Scraper. Lukasz spent some time in fixing the Karaf integration and made quite some progress. So hopefully,
+we can also celebrate his first PR very soon. Of course Niklas has to be named who did his first PR after sitting with us for some MINUTES,
+so this definetly is a record.
+
+Other than that, lovely Chris gave some new people an introduction to PLC4X and we had several people hanging around with us and coding a bit around. Finally, Chris, Björn and I spend some time on the Code Generation thing and we are in quite good state as we are able to nicely generate POJOs in Java and Python.
+
+So it seems reasonable that we can soon generate some serialization / deserialization automatically for DFDL files. As Chris already finished those or S7 this would be a HUGE step forward.


### PR DESCRIPTION
@JulianFeinauer I think your summary from the mailing list was that great it deserves to be on the events page.